### PR TITLE
Improve GPT utility error handling

### DIFF
--- a/src/utils/gpt.ts
+++ b/src/utils/gpt.ts
@@ -1,0 +1,25 @@
+export async function askGPT(prompt: string): Promise<string> {
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI request failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data.choices[0]?.message?.content.trim() ?? "";
+  } catch (err) {
+    console.error(err);
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
- add error handling to `src/utils/gpt.ts`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d8f013d84832d9236c08d20f6f192