### PR TITLE
Use chrome.storage for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# aiviosell-dev
+# AivioSell Chrome Extension
+
+AI-powered tools for Shopee sellers.
+
+## API Key Setup
+
+This extension expects your OpenAI API key to be stored in Chrome's local
+storage. You can do this from the extension options or the console:
+
+```javascript
+chrome.storage.local.set({ apiKey: 'sk-...' });
+```
+
+The key will be retrieved at runtime via `chrome.storage.local.get('apiKey')`
+and used for API requests. Keep your key private and avoid committing it to
+source control.

--- a/src/utils/gpt.ts
+++ b/src/utils/gpt.ts
@@ -1,0 +1,29 @@
+async function getApiKey(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get('apiKey', (result) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      resolve(result.apiKey);
+    });
+  });
+}
+
+export async function askGPT(prompt: string) {
+  const apiKey = await getApiKey();
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: prompt }]
+    })
+  });
+
+  const data = await response.json();
+  return data.choices[0]?.message?.content.trim();
+}


### PR DESCRIPTION
## Summary
- retrieve OpenAI token from `chrome.storage.local`
- add instructions for storing the API key in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d8f029718832d924ab14719faf491