### PR TITLE
Add ESLint and Jest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # AivioSell Chrome Extension
 
 AI-powered tools for Shopee sellers.
+
+## Development Scripts
+
+- `npm run lint` - Run ESLint on all TypeScript and JavaScript files.
+- `npm test` - Execute Jest tests.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+import eslintPluginTs from '@typescript-eslint/eslint-plugin';
+import { parse } from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['**/*.ts', '**/*.js'],
+    languageOptions: {
+      parser: parse,
+      ecmaVersion: 2021,
+      sourceType: 'module',
+    },
+    plugins: { '@typescript-eslint': eslintPluginTs },
+    rules: {
+      'no-unused-vars': 'warn',
+    },
+  },
+];

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "aiviosell-dev",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint . --ext .ts,.js",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.0",
+    "@typescript-eslint/parser": "^5.59.0",
+    "eslint": "^8.43.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.1.0"
+  }
+}

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,0 +1,5 @@
+describe('placeholder', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- setup ESLint with TypeScript support
- add Jest configuration with a placeholder test
- document `lint` and `test` scripts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d94dde47c832dae709225e9eb1d07