### PR TITLE
Add module type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "aiviosell-dev",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "lint": "eslint . --ext .ts,.js",
     "test": "jest"


### PR DESCRIPTION
## Summary
- set the package type to `module` to avoid Node warnings

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9f28fd48832d9474d706653e9b7d