### PR TITLE
Add API key validation to askGPT

### DIFF
--- a/src/utils/gpt.ts
+++ b/src/utils/gpt.ts
@@ -1,9 +1,14 @@
-export async function askGPT(prompt: string) {
+export async function askGPT(prompt: string): Promise<string | undefined> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not defined');
+  }
+
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      Authorization: `Bearer ${apiKey}`
     },
     body: JSON.stringify({
       model: 'gpt-4o',


### PR DESCRIPTION
## Summary
- throw an error when `OPENAI_API_KEY` isn't set
- document return type of `askGPT` as `Promise<string | undefined>`

## Testing
- `npm run lint` *(fails: cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9f2ab788832d8958a0bd8414c2d7