### PR TITLE
Add package-lock and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 AI-powered tools for Shopee sellers.
 
+Before running any of the scripts below, install dependencies with:
+
+```bash
+npm install
+```
+
 ## Development Scripts
 
 - `npm run lint` - Run ESLint on all TypeScript and JavaScript files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "aiviosell-dev",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "aiviosell-dev",
+      "version": "1.0.0",
+      "dependencies": {},
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "@typescript-eslint/eslint-plugin": "^5.59.0",
+        "@typescript-eslint/parser": "^5.59.0",
+        "eslint": "^8.43.0",
+        "jest": "^29.5.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.1.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple `package-lock.json`
- document running `npm install` in README

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9f2b5ee4832da04162360382ea13