### PR TITLE
Add TypeScript build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.tar.bz2
 *.rar
 *.7z
+dist/

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ AI-powered tools for Shopee sellers.
 
 - `npm run lint` - Run ESLint on all TypeScript and JavaScript files.
 - `npm test` - Execute Jest tests.
+- `npm run build` - Transpile TypeScript files to the `dist` directory.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.0",
   "scripts": {
     "lint": "eslint . --ext .ts,.js",
-    "test": "jest"
+    "test": "jest",
+    "build": "tsc"
   },
+  "prepack": "npm run build",
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
   "permissions": ["storage", "activeTab", "scripting"],
   "host_permissions": ["https://shopee.com.my/*"],
   "background": {
-    "service_worker": "src/background.ts"
+    "service_worker": "dist/background.js"
   },
   "action": {
     "default_popup": "src/popup/index.html",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/background.ts"]
+}


### PR DESCRIPTION
## Summary
- compile background script with `tsc`
- reference compiled file in extension manifest
- ignore `dist/` output directory
- document new `npm run build` script
- ensure build runs automatically before packaging

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: jest not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d9edf2fb8832d830b0e1502425539